### PR TITLE
Expose ForgeVersionLoader through public property

### DIFF
--- a/CmlLib.Core.Installer.Forge/MForge.cs
+++ b/CmlLib.Core.Installer.Forge/MForge.cs
@@ -14,6 +14,7 @@ public class MForge
 
     private readonly CMLauncher _launcher;
     private readonly ForgeVersionLoader _versionLoader;
+    public ForgeVersionLoader VersionLoader => _versionLoader;
 
     public MForge(CMLauncher launcher)
     {


### PR DESCRIPTION
A public property called VersionLoader has been added to the MForge class. This property exposes the ForgeVersionLoader object, allowing it to be accessed from outside the class.